### PR TITLE
Improve UI Responsiveness

### DIFF
--- a/Source/WaveformView.h
+++ b/Source/WaveformView.h
@@ -14,7 +14,11 @@
 @interface WaveformView : NSView {
 	SFXEffect * mEffect;
 	SFXSampleBuffer * mSampleBuffer;
+    NSOperationQueue *_waveformImageDrawingQueue;
 }
+    
+@property (nonatomic, strong) NSImage *cachedWaveformImage;
+@property (nonatomic, strong) NSOperationQueue *waveformImageDrawingQueue;
 
 @property (readwrite, retain) SFXEffect * effect;
 


### PR DESCRIPTION
@swillits Rough WIP, this is simply offloading the rendering to a background thread so that the continuous NSSliders don't stutter. The downside is of course that the view refreshes after a noticeable delay in some cases.

I also updated the rendering code so that it only draws every 8th sample which seems to be fine in practice and provides a minor speed bump.

ToDo's:
- [ ] Improve thread safety, there's probably synchronization issues with the sample buffer and SFXEffect which I've overlooked
- [ ] Further speed up / clean up rendering
- [ ] Make the rendering NSOperation properly cancellable even mid-render